### PR TITLE
Fix legacy build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
     "--with-boost-libdir=${pkgs.boost.out}/lib"
     "--with-boost=${pkgs.boost.dev}"
     "--with-magic-file=${pkgs.file}/share/misc/magic.mgc"
+    "--with-rocksdb-includes=${pkgs.rocksdb.src}"
+    "--with-rocksdb-libs=${pkgs.rocksdb.out}"
   ] ++ lib.optional useJemalloc "--enable-jemalloc"
     ++ lib.optional withGraphicsMagick [
     "--with-imagemagick-includes=${pkgs.graphicsmagick}/include/GraphicsMagick"

--- a/shell.nix
+++ b/shell.nix
@@ -5,11 +5,11 @@ let
 
   configureFlags = [
     "--enable-generic"
-    "--with-custom-branding=nix"
-    "--with-custom-version=dev"
     "--with-boost-libdir=${pkgs.boost.out}/lib"
     "--with-boost=${pkgs.boost.dev}"
     "--with-magic-file=${pkgs.file}/share/misc/magic.mgc"
+    "--with-rocksdb-includes=${pkgs.rocksdb.src}"
+    "--with-rocksdb-libs=${pkgs.rocksdb.out}"
     "--enable-jemalloc"
     "--with-imagemagick-includes=${pkgs.graphicsmagick}/include/GraphicsMagick"
     "--with-log-level=DEBUG"


### PR DESCRIPTION
Adds missing configure flags to default.nix, shell.nix (also removes branding flags from shell.nix)